### PR TITLE
Added installing 7 series parts to Vivado install instructions

### DIFF
--- a/website/_selfpaced/20_installing_vivado.md
+++ b/website/_selfpaced/20_installing_vivado.md
@@ -45,6 +45,7 @@ Depending on how you downloaded the files, you will run the installer differentl
   2. On the _Select Product to Install_ screen, choose _Vitis_.
   3. On the customization screen, uncheck everything, except make sure you have:
      *  _SoCs/Zynq-7000_ or _SoCs/Zynq Ultrascale+ MPSoC_, depending on which board type you are using.
+     * Make sure you install the 7 Series parts
      *  Install Cable Drivers
 
   4. On the next screen, agree to all boxes.


### PR DESCRIPTION
I noticed that the instructions for installing Vivado do not mention checking the box to install the 7 series parts list. This came back to bite me when I was trying to run example designs on the ARTY-A7 and BASYS3 boards. I think it would be prudent to mention installing the 7 series parts list since that box is not checked by default and the 7 series is a big part of most of our research. 