### PR TITLE
Added a page for Linkes Google Colaboratory notebooks

### DIFF
--- a/website/_selfpaced/verilog_basics.md
+++ b/website/_selfpaced/verilog_basics.md
@@ -1,0 +1,20 @@
+---
+layout: page
+toc: false
+title: System Verilog Intro Labs
+slug: verilog_basics
+type: fpga_commercial
+order: 11
+---
+
+These labs serve as an intro to digital design with SystemVerilog. They interactively teach concepts, and then walk you through developement process of writing in an HDL, simulating your design, and generating a bitstream. Better yet, all this is done in a Google Colaboratory Notebook so you don't need to worry about configuring your machine. 
+
+Lab 1: Dataflow SystemVerilog [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/westonMS/FPGA_Colablab/blob/master/Labs_All/Lab1_Dataflow_pynb.ipynb)
+
+Lab 2: Arithmetic [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/westonMS/FPGA_Colablab/blob/master/Labs_All/Lab2_Arithmetic_pynb.ipynb)
+
+Lab 3: Seven Segment Display [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/westonMS/FPGA_Colablab/blob/master/Labs_All/Lab3_Seven_Segment_pynb.ipynb)
+
+Lab 4: Stopwatch [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/westonMS/FPGA_Colablab/blob/master/Labs_All/Lab4_Stopwatch_pynb.ipynb)
+
+Lab 5: State Machines [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/westonMS/FPGA_Colablab/blob/master/Labs_All/Lab5_State_Machines_pynb.ipynb)


### PR DESCRIPTION
I added a page for our google colab notebooks for digital design with systemverilog. Right now the links are to notebooks hosted in our developmental repo. We will eventually move the notebooks to be in the computing bootcamp repo, but we will do that when they are more complete. 