### PR TITLE
Updated VS Code Bootcamp Page and Activity

### DIFF
--- a/vscode/input.csv
+++ b/vscode/input.csv
@@ -1,0 +1,13 @@
+Produce,apples,15,$0.25,red
+Grain,bread,1,$2.00,1.00
+Produce,oranges,1,$32.00,orange
+Produce,cucumbers,12,$1.00,green
+Produce,potatoes,2,$0.50,brown
+Produce,apples,15,$0.25,green
+Produce,lemons,1,$32.00,yellow
+Produce,spinach,12,$1.00,green
+Grain,cereal,3,$2.00,0.75
+Produce,beets,2,$0.10,red
+Produce,apples,15,$0.25,yellow
+Produce,oranges,1,$32.00,orange
+Produce,lettuce,12,$1.00,green

--- a/website/_modules/vscode.md
+++ b/website/_modules/vscode.md
@@ -144,22 +144,17 @@ Additional information on Python-specific debugging can be found [here](https://
 VS Code provides the ability to format your code automatically. Depending on the language of your code a formatter may be already available for others you may need to install one. Once a formatter is installed it can be configured to format on save. Some languages and formatters also all formatting on paste or formatting when line is completed. You can manually format the code using the keystroke `Ctrl+Shift+I`. If you choose to use a formatter make sure your formatter and settings match those of the project you are working on.
 
 #### Python
-VS code does not by default have a python formatter. The recommended formatter to use is [Black](https://black.readthedocs.io/en/stable/). To install black simply run 
+VS code does not by default have a python formatter. The recommended formatter to use is [Black](https://black.readthedocs.io/en/stable/). To install black simply install the extension "Black Formatter" by Microsoft within VS Code. Then, open your settings.json file and add the following:
 ```
-pip install black
-```
-Then, open your settings.json file. The settings you will need to add are:
-```
-    "python.formatting.provider": "black",
     "[python]": {"editor.formatOnSave": true}
 ```
-The first setting specifies our chosen formatter. The second enables formatting on save for python files. 
+This setting enables formatting on save for python files. 
 
-To adjust the formatter's settings you may set `"python.formatting.blackArgs"`. For instance, the following example sets the max line length to 100.
+To adjust the formatter's settings you may set `"black-formatter.args"`. For instance, the following example sets the max line length to 100.
 ```
-"python.formatting.blackArgs": ["--line-length", "100"]
+"black-formatter.args": ["--line-length", "100"]
 ```
-See [this page](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html), for more information on Black's settings.
+See black's [extension page](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter) and [documentation](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html) for more information on Black's settings.
 
 #### C/C++
 VS code uses clang-format to format C and C++ code by default. You can enable the formatter to format on save as well as to format a line whenever you type `;` using the following settings.


### PR DESCRIPTION
1. In the vscode module, the instructions on how to set up Black formatter for Python in VS Code are outdated and no longer work, as the recommended setting is deprecated. The newer recommended way to set up this formatter is by installing the official Black formatter extension in the vscode extensions library. This pull changes these instructions to the new, working method of installing Black.
2. The debug activity in the vscode/ directory requires the user to compare a generated output file with an expected output file. However, the "given input file" that was supposed to be included with the activity is missing. This pull adds this missing input.csv file that generates the correct expected output after the debug assignment is completed.